### PR TITLE
Drop setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,16 +33,16 @@ tests: test
 .PHONY: lint fix format
 
 lint-py:  ## lint python with ruff
-	python -m ruff check csp_adapter_slack setup.py
-	python -m ruff format --check csp_adapter_slack setup.py
+	python -m ruff check csp_adapter_slack
+	python -m ruff format --check csp_adapter_slack
 
 lint-docs:  ## lint docs with mdformat and codespell
 	python -m mdformat --check docs/wiki/ README.md
 	python -m codespell_lib docs/wiki/ README.md
 
 fix-py:  ## autoformat python code with ruff
-	python -m ruff check --fix csp_adapter_slack setup.py
-	python -m ruff format csp_adapter_slack setup.py
+	python -m ruff check --fix csp_adapter_slack
+	python -m ruff format csp_adapter_slack
 
 fix-docs:  ## autoformat docs with mdformat and codespell
 	python -m mdformat docs/wiki/ README.md

--- a/setup.py
+++ b/setup.py
@@ -1,1 +1,0 @@
-__import__("setuptools").setup()


### PR DESCRIPTION
It has been enough time, we no longer need to worry about the small circumstances in which `setup.py` was required.